### PR TITLE
Simple-text based parser

### DIFF
--- a/go/iot/protocol/examples/parser/parserExample.go
+++ b/go/iot/protocol/examples/parser/parserExample.go
@@ -1,8 +1,8 @@
 package main
 
 import (
-	parser2 "github.com/census-ecosystem/opencensus-experiments/go/iot/protocol/parser"
 	"fmt"
+	parser2 "github.com/census-ecosystem/opencensus-experiments/go/iot/protocol/parser"
 )
 
 func main() {
@@ -11,10 +11,10 @@ func main() {
 	result, err := parser.Parse([]byte(example))
 	if err != nil {
 		fmt.Println(err)
-	} else{
-		fmt.Println("Name: ",result.Name)
+	} else {
+		fmt.Println("Name: ", result.Name)
 		fmt.Println("Measurement Value: ", result.Measurement)
-		for k, v := range result.Tag{
+		for k, v := range result.Tag {
 			fmt.Println("Key: ", k, " Value: ", v)
 		}
 	}

--- a/go/iot/protocol/examples/parser/parserExample.go
+++ b/go/iot/protocol/examples/parser/parserExample.go
@@ -1,0 +1,21 @@
+package main
+
+import (
+	parser2 "github.com/census-ecosystem/opencensus-experiments/go/iot/protocol/parser"
+	"fmt"
+)
+
+func main() {
+	var example string = "{\"Name\":\"opencensus.io/measure/Temperature\",\"Measurement\":\"23.72\",\"Tag\":{\"ArduinoId\":\"Arduino-1\",\"Date\":\"2018-07-02\"}}"
+	var parser parser2.TextParser
+	result, err := parser.Parse([]byte(example))
+	if err != nil {
+		fmt.Println(err)
+	} else{
+		fmt.Println("Name: ",result.Name)
+		fmt.Println("Measurement Value: ", result.Value)
+		for k, v := range result.Tags{
+			fmt.Println("Key: ", k, " Value: ", v)
+		}
+	}
+}

--- a/go/iot/protocol/examples/parser/parserExample.go
+++ b/go/iot/protocol/examples/parser/parserExample.go
@@ -13,8 +13,8 @@ func main() {
 		fmt.Println(err)
 	} else{
 		fmt.Println("Name: ",result.Name)
-		fmt.Println("Measurement Value: ", result.Value)
-		for k, v := range result.Tags{
+		fmt.Println("Measurement Value: ", result.Measurement)
+		for k, v := range result.Tag{
 			fmt.Println("Key: ", k, " Value: ", v)
 		}
 	}

--- a/go/iot/protocol/examples/pi/main.go
+++ b/go/iot/protocol/examples/pi/main.go
@@ -26,6 +26,7 @@ import (
 	"go.opencensus.io/stats"
 	"go.opencensus.io/stats/view"
 	"go.opencensus.io/tag"
+	"github.com/census-ecosystem/opencensus-experiments/go/iot/protocol/parser"
 )
 
 var (
@@ -71,7 +72,9 @@ func main() {
 		c := &goserial.Config{Name: slaveName, Baud: 9600}
 		var slave opencensus.Slave
 		// Every slave represents one Arduino
-		slave.Initialize(c)
+		//var parser parser.JsonParser
+		var parser parser.TextParser
+		slave.Initialize(c, &parser)
 		slave.Subscribe(census)
 		// The collection would be done in the other go routine.
 		slave.Collect(2 * time.Second)

--- a/go/iot/protocol/examples/pi/main.go
+++ b/go/iot/protocol/examples/pi/main.go
@@ -22,11 +22,11 @@ import (
 	"time"
 
 	"github.com/census-ecosystem/opencensus-experiments/go/iot/protocol/opencensus"
+	"github.com/census-ecosystem/opencensus-experiments/go/iot/protocol/parser"
 	"github.com/huin/goserial"
 	"go.opencensus.io/stats"
 	"go.opencensus.io/stats/view"
 	"go.opencensus.io/tag"
-	"github.com/census-ecosystem/opencensus-experiments/go/iot/protocol/parser"
 )
 
 var (

--- a/go/iot/protocol/examples/pi/main.go
+++ b/go/iot/protocol/examples/pi/main.go
@@ -72,8 +72,8 @@ func main() {
 		c := &goserial.Config{Name: slaveName, Baud: 9600}
 		var slave opencensus.Slave
 		// Every slave represents one Arduino
-		//var parser parser.JsonParser
-		var parser parser.TextParser
+		var parser parser.JsonParser
+		//var parser parser.TextParser
 		slave.Initialize(c, &parser)
 		slave.Subscribe(census)
 		// The collection would be done in the other go routine.

--- a/go/iot/protocol/opencensus/opencensus_base.go
+++ b/go/iot/protocol/opencensus/opencensus_base.go
@@ -112,14 +112,14 @@ func (census *OpenCensusBase) Record(arguments *protocol.MeasureArgument) *proto
 	} else {
 		measure := census.registeredMeasures[measureName]
 
-		ctx, tagExist, err := census.insertTag(arguments.Tags)
+		ctx, tagExist, err := census.insertTag(arguments.Tag)
 
 		if err != nil {
 			return &protocol.Response{protocol.FAIL, err.Error()}
 		}
 
-		if value, err := strconv.ParseFloat(arguments.Value, 64); err != nil {
-			info := fmt.Sprintf("Could not parse the value: %s because %s", arguments.Value, err.Error())
+		if value, err := strconv.ParseFloat(arguments.Measurement, 64); err != nil {
+			info := fmt.Sprintf("Could not parse the value: %s because %s", arguments.Measurement, err.Error())
 			return &protocol.Response{protocol.FAIL, info}
 		} else {
 			//log.Printf("Record Data %v", value)

--- a/go/iot/protocol/opencensus/opencensus_base.go
+++ b/go/iot/protocol/opencensus/opencensus_base.go
@@ -134,7 +134,7 @@ func (census *OpenCensusBase) Record(arguments *protocol.MeasureArgument) *proto
 		}
 
 		if tagExist {
-			return &protocol.Response{protocol.OK, nil}
+			return &protocol.Response{protocol.OK, ""}
 		} else {
 			return &protocol.Response{protocol.UNREGISTERTAG, "Tags key doesn't exist."}
 		}

--- a/go/iot/protocol/opencensus/slave.go
+++ b/go/iot/protocol/opencensus/slave.go
@@ -24,7 +24,7 @@ import (
 	"github.com/census-ecosystem/opencensus-experiments/go/iot/protocol"
 	"github.com/census-ecosystem/opencensus-experiments/go/iot/protocol/parser"
 	"github.com/huin/goserial"
-)
+	)
 
 const (
 	// TODO: We could make it configurable in the future

--- a/go/iot/protocol/opencensus/slave.go
+++ b/go/iot/protocol/opencensus/slave.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/census-ecosystem/opencensus-experiments/go/iot/protocol"
+	"github.com/census-ecosystem/opencensus-experiments/go/iot/protocol/parser"
 	"github.com/huin/goserial"
 )
 
@@ -34,7 +35,8 @@ type Slave struct {
 	listeners []*OpenCensusBase
 	reader    *bufio.Reader
 	// The serial library doesn't support bufio.NewWriter(io.ReadWriteCloser)
-	sender io.ReadWriteCloser
+	sender   io.ReadWriteCloser
+	myParser parser.Parser
 }
 
 func (slave *Slave) notifyCensusToRecord(arguments *protocol.MeasureArgument) {
@@ -48,12 +50,13 @@ func (slave *Slave) Subscribe(listener OpenCensusBase) {
 	slave.listeners = append(slave.listeners, &listener)
 }
 
-func (slave *Slave) Initialize(config *goserial.Config) error {
+func (slave *Slave) Initialize(config *goserial.Config, parser parser.Parser) error {
 	if s, err := goserial.OpenPort(config); err == nil {
 		// It should wait for some time to initialize the arduino end
 		time.Sleep(SETUPDURATION * time.Second)
 		slave.reader = bufio.NewReader(s)
 		slave.sender = s
+		slave.myParser = parser
 		return nil
 	} else {
 		return err
@@ -84,14 +87,13 @@ func (slave *Slave) Collect(period time.Duration) {
 				//TODO: The length of the json is bigger than the buffer size
 				continue
 			} else {
-				var argument protocol.MeasureArgument
-				decodeErr := json.Unmarshal(input, &argument)
+				output, decodeErr := slave.myParser.Parse(input)
 				if decodeErr != nil {
 					// If we don't respond here, there would deadlock between the arduino and Pi.
 					response := protocol.Response{protocol.FAIL, "Json object could not be unmarshalled"}
 					slave.respond(&response)
 				} else {
-					slave.notifyCensusToRecord(&argument)
+					slave.notifyCensusToRecord(&output)
 				}
 			}
 		}

--- a/go/iot/protocol/opencensus/slave.go
+++ b/go/iot/protocol/opencensus/slave.go
@@ -90,7 +90,7 @@ func (slave *Slave) Collect(period time.Duration) {
 				output, decodeErr := slave.myParser.Parse(input)
 				if decodeErr != nil {
 					// If we don't respond here, there would deadlock between the arduino and Pi.
-					response := protocol.Response{protocol.FAIL, "Json object could not be unmarshalled"}
+					response := protocol.Response{protocol.FAIL, "Fail to parse the message because " + decodeErr.Error()}
 					slave.respond(&response)
 				} else {
 					slave.notifyCensusToRecord(&output)

--- a/go/iot/protocol/opencensus/slave.go
+++ b/go/iot/protocol/opencensus/slave.go
@@ -24,7 +24,7 @@ import (
 	"github.com/census-ecosystem/opencensus-experiments/go/iot/protocol"
 	"github.com/census-ecosystem/opencensus-experiments/go/iot/protocol/parser"
 	"github.com/huin/goserial"
-	)
+)
 
 const (
 	// TODO: We could make it configurable in the future

--- a/go/iot/protocol/parser/jsonParser.go
+++ b/go/iot/protocol/parser/jsonParser.go
@@ -1,0 +1,15 @@
+package parser
+
+import (
+	"encoding/json"
+	"github.com/census-ecosystem/opencensus-experiments/go/iot/protocol"
+)
+
+type JsonParser struct {
+}
+
+func (parser *JsonParser) Parse(input []byte) (protocol.MeasureArgument, error) {
+	var output protocol.MeasureArgument
+	decodeErr := json.Unmarshal(input, &output)
+	return output, decodeErr
+}

--- a/go/iot/protocol/parser/parser.go
+++ b/go/iot/protocol/parser/parser.go
@@ -1,0 +1,9 @@
+package parser
+
+import (
+	"github.com/census-ecosystem/opencensus-experiments/go/iot/protocol"
+)
+
+type Parser interface {
+	Parse(input []byte) (protocol.MeasureArgument, error)
+}

--- a/go/iot/protocol/parser/textParser.go
+++ b/go/iot/protocol/parser/textParser.go
@@ -39,16 +39,16 @@ func (parser *TextParser) Parse(input []byte) (protocol.MeasureArgument, error) 
 		return output, errors.Errorf("Value for Name is not valid string")
 	}
 
-	output.Value, ok = parseResult["Measurement"].(string)
+	output.Measurement, ok = parseResult["Measurement"].(string)
 	if ok == false {
 		return output, errors.Errorf("Value for Measurement is not valid string")
 	}
 
-	output.Tags = make(map[string]string)
+	output.Tag = make(map[string]string)
 
 	// Since we would not assert the type of map[string]interface{} to map[string]string, we need to copy one by one
 	for k, v := range parseResult["Tag"].(map[string]interface{}){
-		output.Tags[k], ok = v.(string)
+		output.Tag[k], ok = v.(string)
 		if ok == false {
 			//fmt.Print(test)
 			return output, errors.Errorf("Value for Tag key pair is not valid string")

--- a/go/iot/protocol/parser/textParser.go
+++ b/go/iot/protocol/parser/textParser.go
@@ -1,0 +1,14 @@
+package parser
+
+import (
+	"github.com/census-ecosystem/opencensus-experiments/go/iot/protocol"
+)
+
+type TextParser struct {
+}
+
+func (parser *TextParser) Parse(input []byte) (protocol.MeasureArgument, error) {
+	var output protocol.MeasureArgument
+	// TODO
+	return output, nil
+}

--- a/go/iot/protocol/parser/textParser.go
+++ b/go/iot/protocol/parser/textParser.go
@@ -2,6 +2,8 @@ package parser
 
 import (
 	"github.com/census-ecosystem/opencensus-experiments/go/iot/protocol"
+	"github.com/pkg/errors"
+	"strings"
 )
 
 type TextParser struct {
@@ -9,6 +11,94 @@ type TextParser struct {
 
 func (parser *TextParser) Parse(input []byte) (protocol.MeasureArgument, error) {
 	var output protocol.MeasureArgument
-	// TODO
+	// parseResult is only the transition result of parse. It is in the form of map[string]interface{}
+	// Using the interface{} can make it more general since we might change the protocol in the future.
+	parseResult, err := parser.helper(string(input))
+	if (err != nil){
+		return output, err
+	}
+	var ok bool
+	output.Name, ok= parseResult["Name"].(string)
+	if ok == false{
+		return output, errors.Errorf("Value for Name is not valid string")
+	}
+
+	output.Value, ok = parseResult["Value"].(string)
+	if ok == false{
+		return output, errors.Errorf("Value for Value is not valid string")
+	}
+
+	output.Tags, ok = parseResult["Value"].(map[string]string)
+	if ok == false{
+		return output, errors.Errorf("Value for Tag key pair is not valid string")
+	}
+
 	return output, nil
+}
+
+// Typical Input:
+// {"Name":"opencensus.io/measure/Temperature","Measurement":"23.72","Tag":{"ArduinoId":"Arduino-1","Date":"2018-07-02"}}
+func (parser *TextParser) helper(ss string) (map[string]interface{}, error){
+
+	var res map[string]interface{}
+
+	// First of all, trim all the leading and trailing whitespaces of the input string
+	ss = strings.Trim(ss, " ")
+
+	// Second of all, the trimmed string should has a leading and trailing bracket, which forms a valid bracket
+	if ss[0] != '{' || ss[len(ss) - 1] != '}'{
+		return res, errors.Errorf("Data not started or ended with { / }")
+	}
+
+	// Then trim the leading and trailing bracket of the string
+	ss = ss[1 : len(ss) - 1]
+
+	// Key-value pair in the string are separated by comma.
+	sspairs := strings.Split(ss, ",")
+
+	// If there are not key-value pair in the string, directly return a empty map
+	for _, sspair := range sspairs{
+		// Key and value in the pair are separated by colons.
+		kvpair := strings.Split(sspair, ":")
+
+		if (len(kvpair) != 2){
+			return res, errors.Errorf("More than one colon in the key/value pairs")
+		}
+
+		// before handling the key and value, we need trim all the leading and trailing whitespaces of them
+		key := strings.Trim(kvpair[0], " ")
+		value := strings.Trim(kvpair[1], " ")
+
+		// Since every key / value has a leading / trailing bracket, its size has to be larger than 2.
+		if len(key) <= 2 || len(value) <= 2 {
+			return res, errors.Errorf("Key or Value is Empty")
+		}
+
+		// Every key / value has a leading / trailing bracket, otherwise it's invalid.
+		if key[0] != '"' || key[len(key) - 1] != '"' {
+			return res, errors.Errorf("Key not started or ended with quataion marks")
+		}
+
+		// Character on the both side of value has to form a pair of quataion marks or brackets
+		if !((value[0] == '"' && value[len(value) - 1] == '"') || (value[0] == '{' && value[len(value) - 1] == '}')){
+			return res, errors.Errorf("Value not started / ended with quatation marks / brackets")
+		}
+
+		if (value[0] == '"' && value[len(value) - 1] == '"'){
+			// Value is in the form of string
+			key = key[1 : len(key) - 2]
+			value = value[1 : len(value) - 2]
+			res[key] = value
+		} else{
+			// value is another map of key-value pairs
+			subvalue, err := parser.helper(value)
+			if err != nil {
+				return res, err
+			} else{
+				res[key] = subvalue
+			}
+		}
+	}
+
+	return res, nil
 }

--- a/go/iot/protocol/parser/textParser.go
+++ b/go/iot/protocol/parser/textParser.go
@@ -4,65 +4,169 @@ import (
 	"github.com/census-ecosystem/opencensus-experiments/go/iot/protocol"
 	"github.com/pkg/errors"
 	"strings"
-)
+	)
 
 type TextParser struct {
 }
 
+// In this function, it firstly transform the input byte stream into a map of string -> interface{}.
+// If it manages so, it would extract the required variable as defined in the protocol.
+// Otherwise it would return an un-empty error.
 func (parser *TextParser) Parse(input []byte) (protocol.MeasureArgument, error) {
 	var output protocol.MeasureArgument
 	// parseResult is only the transition result of parse. It is in the form of map[string]interface{}
 	// Using the interface{} can make it more general since we might change the protocol in the future.
-	parseResult, err := parser.helper(string(input))
-	if (err != nil){
+	var parseResult map[string]interface{} = make(map[string]interface{})
+
+	ss := string(input)
+	// First of all, find the outermost layer of bracket.
+	firstBracketPos := strings.Index(ss, "{")
+	lastBracketPos := strings.LastIndex(ss, "}")
+	if firstBracketPos == -1 || lastBracketPos == -1{
+		return output, errors.Errorf("Unpaired brackets in the two end of input string")
+	}
+	// Then trim the leading and trailing bracket of the string
+	ss = ss[firstBracketPos + 1:lastBracketPos]
+	err := parser.helper(ss, parseResult)
+
+	// If the error is not empty, return it.
+	if err != nil {
 		return output, err
 	}
 	var ok bool
-	output.Name, ok= parseResult["Name"].(string)
-	if ok == false{
+	output.Name, ok = parseResult["Name"].(string)
+	if ok == false {
 		return output, errors.Errorf("Value for Name is not valid string")
 	}
 
-	output.Value, ok = parseResult["Value"].(string)
-	if ok == false{
-		return output, errors.Errorf("Value for Value is not valid string")
+	output.Value, ok = parseResult["Measurement"].(string)
+	if ok == false {
+		return output, errors.Errorf("Value for Measurement is not valid string")
 	}
 
-	output.Tags, ok = parseResult["Value"].(map[string]string)
-	if ok == false{
-		return output, errors.Errorf("Value for Tag key pair is not valid string")
+	output.Tags = make(map[string]string)
+
+	// Since we would not assert the type of map[string]interface{} to map[string]string, we need to copy one by one
+	for k, v := range parseResult["Tag"].(map[string]interface{}){
+		output.Tags[k], ok = v.(string)
+		if ok == false {
+			//fmt.Print(test)
+			return output, errors.Errorf("Value for Tag key pair is not valid string")
+		}
 	}
 
 	return output, nil
 }
 
-// Typical Input:
-// {"Name":"opencensus.io/measure/Temperature","Measurement":"23.72","Tag":{"ArduinoId":"Arduino-1","Date":"2018-07-02"}}
-func (parser *TextParser) helper(ss string) (map[string]interface{}, error){
+// The input string of helper function is already trimmed of the leading and trailing bracket.
+func (parser *TextParser) helper(ss string, res map[string]interface{}) error{
 
-	var res map[string]interface{}
+	// Judge whether there are nested brackets
+	var pos int = strings.Index(ss, "{")
 
-	// First of all, trim all the leading and trailing whitespaces of the input string
-	ss = strings.Trim(ss, " ")
+	if pos == -1{
+		// No nested brackets. We could parse the string through the helper function.
+		err := parser.parseWithNoBracket(ss, res)
+		return err
+	} else{
+		// Nested Bracket exists in the string. Currently we know the start of nested string, we firstly find its end
+		count := 1
+		lastBracket := pos + 1
+		for ; lastBracket < len(ss); lastBracket = lastBracket + 1{
+			if ss[lastBracket] == '}'{
+				count = count - 1;
+			}
+			if ss[lastBracket] == '{'{
+				count = count + 1;
+			}
 
-	// Second of all, the trimmed string should has a leading and trailing bracket, which forms a valid bracket
-	if ss[0] != '{' || ss[len(ss) - 1] != '}'{
-		return res, errors.Errorf("Data not started or ended with { / }")
+			if count == 0{
+				break
+			}
+		}
+
+		// If the count is not zero after we traverse the whole string, it means that left and right brackets are not paired
+		if count != 0{
+			return errors.Errorf("Nested bracket unvalid")
+		}
+
+		var nestedResult map[string]interface{} = make(map[string]interface{})
+
+		// Recursively handle the string without leading and trailing brackets
+		err := parser.helper(ss[pos + 1 : lastBracket], nestedResult)
+		if err != nil{
+			return nil
+		} else{
+			// We would need to find the key of this nestedResult
+			start := pos - 1
+			for start >= 0 && ss[start] != '"'{
+				start = start - 1
+			}
+
+			if start == -1{
+				return errors.Errorf("No key found!")
+			}
+
+			end := start - 1
+
+			for (end >= 0 && ss[end] != '"') {
+				end = end - 1
+			}
+
+			if end == -1{
+				return errors.Errorf("No pair of quatation mark found")
+			}
+
+			key := ss[end + 1 : start]
+
+			if len(key) == 0{
+				return errors.Errorf("Key is empty string")
+			}
+
+			res[key] = nestedResult
+
+			// Before 'end', there is no bracket, which means there is no nested brackets. So we call the helper function
+			if err := parser.parseWithNoBracket(ss[0 : end], res); err != nil{
+				return err
+			}
+
+			if lastBracket + 1 == len(ss){
+				// The end of string
+				return nil
+			} else{
+				// There are key-value pairs left behind. We should continue to parse the rest of string
+				if err := parser.helper(ss[lastBracket + 1 : len(ss)], res); err != nil{
+					return err
+				}
+			}
+		}
 	}
 
-	// Then trim the leading and trailing bracket of the string
-	ss = ss[1 : len(ss) - 1]
+	return nil
+}
 
+// This function parses the string without any nested map as the value
+// The input map is the reference to the parse result
+func (parser *TextParser) parseWithNoBracket(ss string, res map[string]interface{}) error {
+
+	ss = strings.Trim(ss, " ")
+	ss = strings.Trim(ss, ",")
+	ss = strings.Trim(ss, " ")
+
+	if len(ss) == 0{
+		// Remaining characters are all whitespaces
+		return nil
+	}
 	// Key-value pair in the string are separated by comma.
 	sspairs := strings.Split(ss, ",")
 
 	// If there are not key-value pair in the string, directly return a empty map
-	for _, sspair := range sspairs{
+	for _, sspair := range sspairs {
 		// Key and value in the pair are separated by colons.
 		kvpair := strings.Split(sspair, ":")
 
-		if (len(kvpair) != 2){
-			return res, errors.Errorf("More than one colon in the key/value pairs")
+		if len(kvpair) != 2 {
+			return errors.Errorf("More than one colon in the key/value pairs")
 		}
 
 		// before handling the key and value, we need trim all the leading and trailing whitespaces of them
@@ -71,34 +175,23 @@ func (parser *TextParser) helper(ss string) (map[string]interface{}, error){
 
 		// Since every key / value has a leading / trailing bracket, its size has to be larger than 2.
 		if len(key) <= 2 || len(value) <= 2 {
-			return res, errors.Errorf("Key or Value is Empty")
+			return errors.Errorf("Key or Value is Empty")
 		}
 
 		// Every key / value has a leading / trailing bracket, otherwise it's invalid.
 		if key[0] != '"' || key[len(key) - 1] != '"' {
-			return res, errors.Errorf("Key not started or ended with quataion marks")
+			return errors.Errorf("Key not started or ended with quataion marks")
 		}
 
-		// Character on the both side of value has to form a pair of quataion marks or brackets
-		if !((value[0] == '"' && value[len(value) - 1] == '"') || (value[0] == '{' && value[len(value) - 1] == '}')){
-			return res, errors.Errorf("Value not started / ended with quatation marks / brackets")
+		// Character on the both side of value has to form a pair of quataion marks
+		if value[0] != '"' || value[len(value) - 1] != '"' {
+			return errors.Errorf("Value not started / ended with quatation marks / brackets")
 		}
 
-		if (value[0] == '"' && value[len(value) - 1] == '"'){
-			// Value is in the form of string
-			key = key[1 : len(key) - 2]
-			value = value[1 : len(value) - 2]
-			res[key] = value
-		} else{
-			// value is another map of key-value pairs
-			subvalue, err := parser.helper(value)
-			if err != nil {
-				return res, err
-			} else{
-				res[key] = subvalue
-			}
-		}
+		key = key[1 : len(key) - 1]
+		value = value[1 : len(value) - 1]
+		res[key] = value
 	}
 
-	return res, nil
+	return nil
 }

--- a/go/iot/protocol/protocol.go
+++ b/go/iot/protocol/protocol.go
@@ -23,8 +23,8 @@ const (
 
 type MeasureArgument struct {
 	Name  string
-	Value string
-	Tags  map[string]string
+	Measurement string
+	Tag  map[string]string
 }
 
 type Response struct {

--- a/go/iot/protocol/test/parser_test.go
+++ b/go/iot/protocol/test/parser_test.go
@@ -18,16 +18,16 @@ func Test_parser_normal (t *testing.T){
 			t.Error("Name of parse result is wrong as ", result.Name, " Correct answer is opencensus.io/measure/Temperature")
 		}
 
-		if result.Value != "23.72"{
-			t.Error("Value of parse result is wrong as ", result.Value, " Correct answer is 23.72")
+		if result.Measurement != "23.72"{
+			t.Error("Measurement of parse result is wrong as ", result.Measurement, " Correct answer is 23.72")
 		}
 
-		if result.Tags["ArduinoId"] != "Arduino-1"{
-			t.Error("Tag ArduinoId of parse result is wrong as ", result.Tags["ArduinoId"], " Correct answer is Arduino-1")
+		if result.Tag["ArduinoId"] != "Arduino-1"{
+			t.Error("Tag ArduinoId of parse result is wrong as ", result.Tag["ArduinoId"], " Correct answer is Arduino-1")
 		}
 
-		if result.Tags["Date"] != "2018-07-02"{
-			t.Error("Tag ArduinoId of parse result is wrong as ", result.Tags["Date"], " Correct answer is 2018-07-02")
+		if result.Tag["Date"] != "2018-07-02"{
+			t.Error("Tag ArduinoId of parse result is wrong as ", result.Tag["Date"], " Correct answer is 2018-07-02")
 		}
 	}
 }
@@ -44,16 +44,16 @@ func Test_parser_normal_with_space (t *testing.T){
 			t.Error("Name of parse result is wrong as ", result.Name, " Correct answer is opencensus.io/measure/Temperature")
 		}
 
-		if result.Value != "23.72"{
-			t.Error("Value of parse result is wrong as ", result.Value, " Correct answer is 23.72")
+		if result.Measurement != "23.72"{
+			t.Error("Measurement of parse result is wrong as ", result.Measurement, " Correct answer is 23.72")
 		}
 
-		if result.Tags["ArduinoId"] != "Arduino-1"{
-			t.Error("Tag ArduinoId of parse result is wrong as ", result.Tags["ArduinoId"], " Correct answer is Arduino-1")
+		if result.Tag["ArduinoId"] != "Arduino-1"{
+			t.Error("Tag ArduinoId of parse result is wrong as ", result.Tag["ArduinoId"], " Correct answer is Arduino-1")
 		}
 
-		if result.Tags["Date"] != "2018-07-02"{
-			t.Error("Tag ArduinoId of parse result is wrong as ", result.Tags["Date"], " Correct answer is 2018-07-02")
+		if result.Tag["Date"] != "2018-07-02"{
+			t.Error("Tag ArduinoId of parse result is wrong as ", result.Tag["Date"], " Correct answer is 2018-07-02")
 		}
 	}
 }
@@ -70,16 +70,16 @@ func Test_parser_normal_unordered (t *testing.T){
 			t.Error("Name of parse result is wrong as ", result.Name, " Correct answer is opencensus.io/measure/Temperature")
 		}
 
-		if result.Value != "23.72"{
-			t.Error("Value of parse result is wrong as ", result.Value, " Correct answer is 23.72")
+		if result.Measurement != "23.72"{
+			t.Error("Measurement of parse result is wrong as ", result.Measurement, " Correct answer is 23.72")
 		}
 
-		if result.Tags["ArduinoId"] != "Arduino-1"{
-			t.Error("Tag ArduinoId of parse result is wrong as ", result.Tags["ArduinoId"], " Correct answer is Arduino-1")
+		if result.Tag["ArduinoId"] != "Arduino-1"{
+			t.Error("Tag ArduinoId of parse result is wrong as ", result.Tag["ArduinoId"], " Correct answer is Arduino-1")
 		}
 
-		if result.Tags["Date"] != "2018-07-02"{
-			t.Error("Tag ArduinoId of parse result is wrong as ", result.Tags["Date"], " Correct answer is 2018-07-02")
+		if result.Tag["Date"] != "2018-07-02"{
+			t.Error("Tag ArduinoId of parse result is wrong as ", result.Tag["Date"], " Correct answer is 2018-07-02")
 		}
 	}
 }

--- a/go/iot/protocol/test/parser_test.go
+++ b/go/iot/protocol/test/parser_test.go
@@ -1,0 +1,107 @@
+package test
+
+import (
+	"testing"
+	parser2 "github.com/census-ecosystem/opencensus-experiments/go/iot/protocol/parser"
+	)
+var parser parser2.TextParser
+
+// Test Example without any whitespace
+// {"Name":"opencensus.io/measure/Temperature","Measurement":"23.72","Tag":{"ArduinoId":"Arduino-1","Date":"2018-07-02"}}
+func Test_parser_normal (t *testing.T){
+	var testEg string = "{\"Name\":\"opencensus.io/measure/Temperature\",\"Measurement\":\"23.72\",\"Tag\":{\"ArduinoId\":\"Arduino-1\",\"Date\":\"2018-07-02\"}}"
+	result, err := parser.Parse([]byte(testEg))
+	if err != nil {
+		t.Error(err)
+	} else{
+		if result.Name != "opencensus.io/measure/Temperature"{
+			t.Error("Name of parse result is wrong as ", result.Name, " Correct answer is opencensus.io/measure/Temperature")
+		}
+
+		if result.Value != "23.72"{
+			t.Error("Value of parse result is wrong as ", result.Value, " Correct answer is 23.72")
+		}
+
+		if result.Tags["ArduinoId"] != "Arduino-1"{
+			t.Error("Tag ArduinoId of parse result is wrong as ", result.Tags["ArduinoId"], " Correct answer is Arduino-1")
+		}
+
+		if result.Tags["Date"] != "2018-07-02"{
+			t.Error("Tag ArduinoId of parse result is wrong as ", result.Tags["Date"], " Correct answer is 2018-07-02")
+		}
+	}
+}
+
+// Test Example with some whitespaces
+// { "Name": "opencensus.io/measure/Temperature" , "Measurement":"23.72" , "Tag":{"ArduinoId" : "Arduino-1" , "Date" : "2018-07-02"  } }
+func Test_parser_normal_with_space (t *testing.T){
+	var testEg string = "{ \"Name\": \"opencensus.io/measure/Temperature\" , \"Measurement\":\"23.72\" , \"Tag\" : { \"ArduinoId\" : \"Arduino-1\" , \"Date\" : \"2018-07-02\"  } }"
+	result, err := parser.Parse([]byte(testEg))
+	if err != nil {
+		t.Error(err)
+	} else{
+		if result.Name != "opencensus.io/measure/Temperature"{
+			t.Error("Name of parse result is wrong as ", result.Name, " Correct answer is opencensus.io/measure/Temperature")
+		}
+
+		if result.Value != "23.72"{
+			t.Error("Value of parse result is wrong as ", result.Value, " Correct answer is 23.72")
+		}
+
+		if result.Tags["ArduinoId"] != "Arduino-1"{
+			t.Error("Tag ArduinoId of parse result is wrong as ", result.Tags["ArduinoId"], " Correct answer is Arduino-1")
+		}
+
+		if result.Tags["Date"] != "2018-07-02"{
+			t.Error("Tag ArduinoId of parse result is wrong as ", result.Tags["Date"], " Correct answer is 2018-07-02")
+		}
+	}
+}
+
+// Test Example with different order of key-value pairs
+// { "Name": "opencensus.io/measure/Temperature" , "Tag":{"ArduinoId" : "Arduino-1" , "Date" : "2018-07-02"  } , "Measurement":"23.72" }
+func Test_parser_normal_unordered (t *testing.T){
+	var testEg string = "{ \"Name\": \"opencensus.io/measure/Temperature\" , \"Tag\" : { \"ArduinoId\" : \"Arduino-1\" , \"Date\" : \"2018-07-02\"  } , \"Measurement\":\"23.72\" }"
+	result, err := parser.Parse([]byte(testEg))
+	if err != nil {
+		t.Error(err)
+	} else{
+		if result.Name != "opencensus.io/measure/Temperature"{
+			t.Error("Name of parse result is wrong as ", result.Name, " Correct answer is opencensus.io/measure/Temperature")
+		}
+
+		if result.Value != "23.72"{
+			t.Error("Value of parse result is wrong as ", result.Value, " Correct answer is 23.72")
+		}
+
+		if result.Tags["ArduinoId"] != "Arduino-1"{
+			t.Error("Tag ArduinoId of parse result is wrong as ", result.Tags["ArduinoId"], " Correct answer is Arduino-1")
+		}
+
+		if result.Tags["Date"] != "2018-07-02"{
+			t.Error("Tag ArduinoId of parse result is wrong as ", result.Tags["Date"], " Correct answer is 2018-07-02")
+		}
+	}
+}
+
+// Test Example with unpaired brackets in the end of input string
+// { "Name": "opencensus.io/measure/Temperature" , "Tag":{"ArduinoId" : "Arduino-1" , "Date" : "2018-07-02"  } , "Measurement":"23.72" }}
+func Test_parser_abnormal_unpaired_brackets (t *testing.T){
+	var testEg string = "{ \"Name\": \"opencensus.io/measure/Temperature\" , \"Tag\" : { \"ArduinoId\" : \"Arduino-1\" , \"Date\" : \"2018-07-02\"  } , \"Measurement\":\"23.72\" }}"
+	_, err := parser.Parse([]byte(testEg))
+	if err != nil {
+	} else{
+		t.Error("There is one more bracket in the end of input string")
+	}
+}
+
+// Test Example with different keys as defined in the protocol
+// { "Name": "opencensus.io/measure/Temperature" , "Tag":{"ArduinoId" : "Arduino-1" , "Date" : "2018-07-02"  } , "Meaurement":"23.72" }}
+func Test_parser_abnormal_wrong_key (t *testing.T){
+	var testEg string = "{ \"Name\": \"opencensus.io/measure/Temperature\" , \"Tag\" : { \"ArduinoId\" : \"Arduino-1\" , \"Date\" : \"2018-07-02\"  } , \"Meaurement\":\"23.72\" }"
+	_, err := parser.Parse([]byte(testEg))
+	if err != nil {
+	} else{
+		t.Error("It should be Measurement instead of Meaurement")
+	}
+}

--- a/go/iot/protocol/test/parser_test.go
+++ b/go/iot/protocol/test/parser_test.go
@@ -1,32 +1,33 @@
 package test
 
 import (
-	"testing"
 	parser2 "github.com/census-ecosystem/opencensus-experiments/go/iot/protocol/parser"
-	)
+	"testing"
+)
+
 var parser parser2.TextParser
 
 // Test Example without any whitespace
 // {"Name":"opencensus.io/measure/Temperature","Measurement":"23.72","Tag":{"ArduinoId":"Arduino-1","Date":"2018-07-02"}}
-func Test_parser_normal (t *testing.T){
+func Test_parser_normal(t *testing.T) {
 	var testEg string = "{\"Name\":\"opencensus.io/measure/Temperature\",\"Measurement\":\"23.72\",\"Tag\":{\"ArduinoId\":\"Arduino-1\",\"Date\":\"2018-07-02\"}}"
 	result, err := parser.Parse([]byte(testEg))
 	if err != nil {
 		t.Error(err)
-	} else{
-		if result.Name != "opencensus.io/measure/Temperature"{
+	} else {
+		if result.Name != "opencensus.io/measure/Temperature" {
 			t.Error("Name of parse result is wrong as ", result.Name, " Correct answer is opencensus.io/measure/Temperature")
 		}
 
-		if result.Measurement != "23.72"{
+		if result.Measurement != "23.72" {
 			t.Error("Measurement of parse result is wrong as ", result.Measurement, " Correct answer is 23.72")
 		}
 
-		if result.Tag["ArduinoId"] != "Arduino-1"{
+		if result.Tag["ArduinoId"] != "Arduino-1" {
 			t.Error("Tag ArduinoId of parse result is wrong as ", result.Tag["ArduinoId"], " Correct answer is Arduino-1")
 		}
 
-		if result.Tag["Date"] != "2018-07-02"{
+		if result.Tag["Date"] != "2018-07-02" {
 			t.Error("Tag ArduinoId of parse result is wrong as ", result.Tag["Date"], " Correct answer is 2018-07-02")
 		}
 	}
@@ -34,25 +35,25 @@ func Test_parser_normal (t *testing.T){
 
 // Test Example with some whitespaces
 // { "Name": "opencensus.io/measure/Temperature" , "Measurement":"23.72" , "Tag":{"ArduinoId" : "Arduino-1" , "Date" : "2018-07-02"  } }
-func Test_parser_normal_with_space (t *testing.T){
+func Test_parser_normal_with_space(t *testing.T) {
 	var testEg string = "{ \"Name\": \"opencensus.io/measure/Temperature\" , \"Measurement\":\"23.72\" , \"Tag\" : { \"ArduinoId\" : \"Arduino-1\" , \"Date\" : \"2018-07-02\"  } }"
 	result, err := parser.Parse([]byte(testEg))
 	if err != nil {
 		t.Error(err)
-	} else{
-		if result.Name != "opencensus.io/measure/Temperature"{
+	} else {
+		if result.Name != "opencensus.io/measure/Temperature" {
 			t.Error("Name of parse result is wrong as ", result.Name, " Correct answer is opencensus.io/measure/Temperature")
 		}
 
-		if result.Measurement != "23.72"{
+		if result.Measurement != "23.72" {
 			t.Error("Measurement of parse result is wrong as ", result.Measurement, " Correct answer is 23.72")
 		}
 
-		if result.Tag["ArduinoId"] != "Arduino-1"{
+		if result.Tag["ArduinoId"] != "Arduino-1" {
 			t.Error("Tag ArduinoId of parse result is wrong as ", result.Tag["ArduinoId"], " Correct answer is Arduino-1")
 		}
 
-		if result.Tag["Date"] != "2018-07-02"{
+		if result.Tag["Date"] != "2018-07-02" {
 			t.Error("Tag ArduinoId of parse result is wrong as ", result.Tag["Date"], " Correct answer is 2018-07-02")
 		}
 	}
@@ -60,25 +61,25 @@ func Test_parser_normal_with_space (t *testing.T){
 
 // Test Example with different order of key-value pairs
 // { "Name": "opencensus.io/measure/Temperature" , "Tag":{"ArduinoId" : "Arduino-1" , "Date" : "2018-07-02"  } , "Measurement":"23.72" }
-func Test_parser_normal_unordered (t *testing.T){
+func Test_parser_normal_unordered(t *testing.T) {
 	var testEg string = "{ \"Name\": \"opencensus.io/measure/Temperature\" , \"Tag\" : { \"ArduinoId\" : \"Arduino-1\" , \"Date\" : \"2018-07-02\"  } , \"Measurement\":\"23.72\" }"
 	result, err := parser.Parse([]byte(testEg))
 	if err != nil {
 		t.Error(err)
-	} else{
-		if result.Name != "opencensus.io/measure/Temperature"{
+	} else {
+		if result.Name != "opencensus.io/measure/Temperature" {
 			t.Error("Name of parse result is wrong as ", result.Name, " Correct answer is opencensus.io/measure/Temperature")
 		}
 
-		if result.Measurement != "23.72"{
+		if result.Measurement != "23.72" {
 			t.Error("Measurement of parse result is wrong as ", result.Measurement, " Correct answer is 23.72")
 		}
 
-		if result.Tag["ArduinoId"] != "Arduino-1"{
+		if result.Tag["ArduinoId"] != "Arduino-1" {
 			t.Error("Tag ArduinoId of parse result is wrong as ", result.Tag["ArduinoId"], " Correct answer is Arduino-1")
 		}
 
-		if result.Tag["Date"] != "2018-07-02"{
+		if result.Tag["Date"] != "2018-07-02" {
 			t.Error("Tag ArduinoId of parse result is wrong as ", result.Tag["Date"], " Correct answer is 2018-07-02")
 		}
 	}
@@ -86,22 +87,22 @@ func Test_parser_normal_unordered (t *testing.T){
 
 // Test Example with unpaired brackets in the end of input string
 // { "Name": "opencensus.io/measure/Temperature" , "Tag":{"ArduinoId" : "Arduino-1" , "Date" : "2018-07-02"  } , "Measurement":"23.72" }}
-func Test_parser_abnormal_unpaired_brackets (t *testing.T){
+func Test_parser_abnormal_unpaired_brackets(t *testing.T) {
 	var testEg string = "{ \"Name\": \"opencensus.io/measure/Temperature\" , \"Tag\" : { \"ArduinoId\" : \"Arduino-1\" , \"Date\" : \"2018-07-02\"  } , \"Measurement\":\"23.72\" }}"
 	_, err := parser.Parse([]byte(testEg))
 	if err != nil {
-	} else{
+	} else {
 		t.Error("There is one more bracket in the end of input string")
 	}
 }
 
 // Test Example with different keys as defined in the protocol
 // { "Name": "opencensus.io/measure/Temperature" , "Tag":{"ArduinoId" : "Arduino-1" , "Date" : "2018-07-02"  } , "Meaurement":"23.72" }}
-func Test_parser_abnormal_wrong_key (t *testing.T){
+func Test_parser_abnormal_wrong_key(t *testing.T) {
 	var testEg string = "{ \"Name\": \"opencensus.io/measure/Temperature\" , \"Tag\" : { \"ArduinoId\" : \"Arduino-1\" , \"Date\" : \"2018-07-02\"  } , \"Meaurement\":\"23.72\" }"
 	_, err := parser.Parse([]byte(testEg))
 	if err != nil {
-	} else{
+	} else {
 		t.Error("It should be Measurement instead of Meaurement")
 	}
 }


### PR DESCRIPTION
Instead of using JSON library in the raspberry end,  I implemented a parser based on simple text.

The difference is that this parser would be more robust.  It could tolerate more mistakes to some extents. I add some tests in the test directory. You could see the example in it.

The original version of the parser is commit 9b1f445. It splits the string base on ',' and handles each k-v pair.  But it won't work if the input string has nested key-value map.  The commit fffce6c is to fix this bug. 

At last, I test the parser in the environment of gLinux and arduino.