### PR TITLE
Update Stackdriver log correlation demos for opencensus-java 0.16.0.

### DIFF
--- a/java/log_correlation/stackdriver/java_util_logging/README.md
+++ b/java/log_correlation/stackdriver/java_util_logging/README.md
@@ -18,6 +18,6 @@ Sampled trace in Stackdriver, with log entries displayed below each span:
 
 ![Traces](images/trace.png "Example trace in Stackdriver")
 
-Log entries containing "trace", "spanId", and "openCensusTraceSampled" fields in Stackdriver:
+Log entries containing "trace", "spanId", and "opencensusTraceSampled" fields in Stackdriver:
 
 ![Logs](images/logs.png "Example logs in Stackdriver")

--- a/java/log_correlation/stackdriver/java_util_logging/build.gradle
+++ b/java/log_correlation/stackdriver/java_util_logging/build.gradle
@@ -7,9 +7,9 @@ repositories {
 }
 
 group = "io.opencensus"
-version = "0.16.0-SNAPSHOT"
+version = "0.17.0-SNAPSHOT"
 
-def opencensusVersion = "0.15.0"
+def opencensusVersion = "0.16.0"
 
 tasks.withType(JavaCompile) {
     sourceCompatibility = '1.7'

--- a/java/log_correlation/stackdriver/logback/README.md
+++ b/java/log_correlation/stackdriver/logback/README.md
@@ -18,6 +18,6 @@ Sampled trace in Stackdriver, with log entries displayed below each span:
 
 ![Traces](images/trace.png "Example trace in Stackdriver")
 
-Log entries containing "trace", "spanId", and "openCensusTraceSampled" fields in Stackdriver:
+Log entries containing "trace", "spanId", and "opencensusTraceSampled" fields in Stackdriver:
 
 ![Logs](images/logs.png "Example logs in Stackdriver")

--- a/java/log_correlation/stackdriver/logback/build.gradle
+++ b/java/log_correlation/stackdriver/logback/build.gradle
@@ -7,9 +7,9 @@ repositories {
 }
 
 group = "io.opencensus"
-version = "0.16.0-SNAPSHOT"
+version = "0.17.0-SNAPSHOT"
 
-def opencensusVersion = "0.15.0"
+def opencensusVersion = "0.16.0"
 
 tasks.withType(JavaCompile) {
     sourceCompatibility = '1.7'


### PR DESCRIPTION
This commit also updates the name of the trace sampled field for
https://github.com/census-instrumentation/opencensus-java/pull/1418.