### PR TITLE
Upgrade Stackdriver log correlation dependencies on google-cloud-logging.

### DIFF
--- a/java/log_correlation/stackdriver/java_util_logging/build.gradle
+++ b/java/log_correlation/stackdriver/java_util_logging/build.gradle
@@ -22,7 +22,7 @@ dependencies {
 
     runtime "io.opencensus:opencensus-contrib-log-correlation-stackdriver:${opencensusVersion}",
             "io.opencensus:opencensus-impl-lite:${opencensusVersion}",
-            "com.google.cloud:google-cloud-logging:0.48.0-alpha"
+            "com.google.cloud:google-cloud-logging:1.44.0"
 }
 
 apply plugin: 'application'

--- a/java/log_correlation/stackdriver/logback/build.gradle
+++ b/java/log_correlation/stackdriver/logback/build.gradle
@@ -23,7 +23,7 @@ dependencies {
 
     runtime "io.opencensus:opencensus-contrib-log-correlation-stackdriver:${opencensusVersion}",
             "io.opencensus:opencensus-impl-lite:${opencensusVersion}",
-            "com.google.cloud:google-cloud-logging-logback:0.48.0-alpha"
+            "com.google.cloud:google-cloud-logging-logback:0.62.0-alpha"
 }
 
 apply plugin: 'application'


### PR DESCRIPTION
This commit upgrades google-cloud-logging to 1.44.0 and upgrades
google-cloud-logging-logback to 0.62.0-alpha.