### PR TITLE
Log correlation demos: Upgrade opencensus-java to 0.16.1.

### DIFF
--- a/java/log_correlation/log4j2/build.gradle
+++ b/java/log_correlation/log4j2/build.gradle
@@ -12,7 +12,7 @@ repositories {
 group = "io.opencensus"
 version = "0.17.0-SNAPSHOT"
 
-def opencensusVersion = "0.16.0"
+def opencensusVersion = "0.16.1"
 
 def jacksonVersion = '2.9.6'
 

--- a/java/log_correlation/stackdriver/java_util_logging/build.gradle
+++ b/java/log_correlation/stackdriver/java_util_logging/build.gradle
@@ -9,7 +9,7 @@ repositories {
 group = "io.opencensus"
 version = "0.17.0-SNAPSHOT"
 
-def opencensusVersion = "0.16.0"
+def opencensusVersion = "0.16.1"
 
 tasks.withType(JavaCompile) {
     sourceCompatibility = '1.7'

--- a/java/log_correlation/stackdriver/logback/build.gradle
+++ b/java/log_correlation/stackdriver/logback/build.gradle
@@ -9,7 +9,7 @@ repositories {
 group = "io.opencensus"
 version = "0.17.0-SNAPSHOT"
 
-def opencensusVersion = "0.16.0"
+def opencensusVersion = "0.16.1"
 
 tasks.withType(JavaCompile) {
     sourceCompatibility = '1.7'


### PR DESCRIPTION
opencensus-java 0.16.1 has a fix for
https://github.com/census-instrumentation/opencensus-java/issues/1436, which
affected the Log4j log correlation demo.