### PR TITLE
Export to OC agent in python services

### DIFF
--- a/interoptest/src/pythonservice/grpcserver.py
+++ b/interoptest/src/pythonservice/grpcserver.py
@@ -23,7 +23,7 @@ from contextlib import contextmanager
 import logging
 import sys
 
-from opencensus.trace.exporters import logging_exporter
+from opencensus.trace.exporters.ocagent import trace_exporter
 from opencensus.trace.ext.grpc import server_interceptor
 from opencensus.trace.samplers import always_on
 import grpc
@@ -38,6 +38,7 @@ logger.setLevel(logging.DEBUG)
 logger.addHandler(logging.StreamHandler(sys.stdout))
 
 GRPC_TPE_WORKERS = 10
+SERVICE_NAME = "interop test python grpc binary service"
 
 
 class GRPCBinaryTestServer(pb2_grpc.TestExecutionServiceServicer):
@@ -84,7 +85,8 @@ def register(host='localhost', port=pb2.PYTHON_GRPC_BINARY_PROPAGATION_PORT):
 def serve_grpc_binary(port=pb2.PYTHON_GRPC_BINARY_PROPAGATION_PORT):
     """Run the GRPC/binary server, shut down on exiting context."""
     interceptor = server_interceptor.OpenCensusServerInterceptor(
-        always_on.AlwaysOnSampler(), logging_exporter.LoggingExporter())
+        always_on.AlwaysOnSampler(),
+        trace_exporter.TraceExporter(SERVICE_NAME))
     server = grpc.server(
         futures.ThreadPoolExecutor(max_workers=GRPC_TPE_WORKERS),
         interceptors=(interceptor,)

--- a/interoptest/src/pythonservice/service.py
+++ b/interoptest/src/pythonservice/service.py
@@ -21,6 +21,7 @@ from uuid import uuid4
 import logging
 import sys
 
+from opencensus.trace.exporters.ocagent import trace_exporter
 from opencensus.trace.ext import requests as requests_wrapper
 from opencensus.trace.tracers import context_tracer
 import grpc
@@ -30,7 +31,9 @@ import interoperability_test_pb2 as pb2
 import interoperability_test_pb2_grpc as pb2_grpc
 
 # Monkey patch the requests library
-requests_wrapper.trace.trace_integration(context_tracer.ContextTracer())
+requests_wrapper.trace.trace_integration(
+    context_tracer.ContextTracer(
+        exporter=trace_exporter.TraceExporter("requests")))
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)


### PR DESCRIPTION
This diff replaces the logging exporter in each service with the agent exporter, and replaces the gcloud format propagator in the flask service with a W3C tracecontext propagator.

This is largely untested except to check that the right exporter/propagator is being set. We may have to configure the exporter for the agent used in the interop test.