### PR TITLE
Add script to run tests

### DIFF
--- a/interoptest/interoperability_test_pb2.py
+++ b/interoptest/interoperability_test_pb2.py
@@ -1,0 +1,1 @@
+src/pythonservice/interoperability_test_pb2.py

--- a/interoptest/interoperability_test_pb2_grpc.py
+++ b/interoptest/interoperability_test_pb2_grpc.py
@@ -1,0 +1,1 @@
+src/pythonservice/interoperability_test_pb2_grpc.py

--- a/interoptest/requirements.txt
+++ b/interoptest/requirements.txt
@@ -1,2 +1,3 @@
 docopt
 grpcio
+protobuf

--- a/interoptest/requirements.txt
+++ b/interoptest/requirements.txt
@@ -1,0 +1,2 @@
+docopt
+grpcio

--- a/interoptest/run.py
+++ b/interoptest/run.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python
+#
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Run the OpenCensus interop test and print the results.
+
+Usage:
+  run [--host=<host> [--port=<port>]] [--verbose]
+  run (-h | --help)
+
+Options:
+  -h --help         Show help (this screen)
+  -v --verbose      Verbose output
+  -o --host=<host>  Test service host [default: localhost]
+  -p --port=<port>  Test service port [default: 10000]
+
+"""
+
+import logging
+import sys
+import time
+
+from docopt import docopt
+import grpc
+
+import interoperability_test_pb2 as pb2
+import interoperability_test_pb2_grpc as pb2_grpc
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.WARN)
+logger.addHandler(logging.StreamHandler(sys.stdout))
+
+# Seconds between calls to get test result
+POLL_INTERVAL = 1
+
+
+def call_test(host, port):
+    client = pb2_grpc.InteropTestServiceStub(
+        channel=grpc.insecure_channel('{}:{}'.format(host, port)))
+    logger.debug("Kicking off test run on %s:%s", host, port)
+    run_id = int(client.run(pb2.InteropRunRequest()).id)
+    logger.debug("Got test run ID %s", run_id)
+    response = client.result(pb2.InteropResultRequest(id=run_id))
+    while response is None or response.status.status == pb2.RUNNING:
+        logger.debug("Waiting for test run %s to finish...", run_id)
+        time.sleep(POLL_INTERVAL)
+        response = client.result(pb2.InteropResultRequest(id=run_id))
+    logger.debug("Done test run %s", run_id)
+    return response
+
+
+def main():
+    args = docopt(__doc__)
+    if args.get('--verbose'):
+        logger.setLevel(logging.DEBUG)
+    host = args.get('--host', 'localhost')
+    port = args.get('--port', 10000)
+    results = call_test(host, port)
+    logger.debug("Results:")
+    print(results)
+
+
+if __name__ == "__main__":
+    main()

--- a/interoptest/run.py
+++ b/interoptest/run.py
@@ -17,17 +17,20 @@
 Run the OpenCensus interop test and print the results.
 
 Usage:
-  run [--host=<host> [--port=<port>]] [--verbose]
+  run [--host=<host> [--port=<port>]] [--timeout=<timeout>] [--verbose]
   run (-h | --help)
 
 Options:
-  -h --help         Show help (this screen)
-  -v --verbose      Verbose output
-  -o --host=<host>  Test service host [default: localhost]
-  -p --port=<port>  Test service port [default: 10000]
+  -h --help               Show help (this screen)
+  -v --verbose            Verbose output
+  -t --timeout=<timeout>  Seconds to wait for service calls [default: 60]
+  -o --host=<host>        Test service host [default: localhost]
+  -p --port=<port>        Test service port [default: 10000]
 
 """
 
+from concurrent import futures
+from threading import Event
 import logging
 import sys
 import time
@@ -38,6 +41,7 @@ import grpc
 import interoperability_test_pb2 as pb2
 import interoperability_test_pb2_grpc as pb2_grpc
 
+
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.WARN)
 logger.addHandler(logging.StreamHandler(sys.stdout))
@@ -46,17 +50,41 @@ logger.addHandler(logging.StreamHandler(sys.stdout))
 POLL_INTERVAL = 1
 
 
-def call_test(host, port):
+def call_test(host, port, executor, timeout=None):
     client = pb2_grpc.InteropTestServiceStub(
         channel=grpc.insecure_channel('{}:{}'.format(host, port)))
+
     logger.debug("Kicking off test run on %s:%s", host, port)
-    run_id = int(client.run(pb2.InteropRunRequest()).id)
+    run_future = executor.submit(client.run, pb2.InteropRunRequest())
+    start_time = time.time()
+    run_id = run_future.result(timeout=timeout).id
     logger.debug("Got test run ID %s", run_id)
-    response = client.result(pb2.InteropResultRequest(id=run_id))
-    while response is None or response.status.status == pb2.RUNNING:
-        logger.debug("Waiting for test run %s to finish...", run_id)
-        time.sleep(POLL_INTERVAL)
+
+    timeout_event = Event()
+
+    def poll_server():
         response = client.result(pb2.InteropResultRequest(id=run_id))
+        while response.status.status == pb2.RUNNING:
+            logger.debug("Waiting for test run %s to finish...", run_id)
+            if timeout_event.wait(POLL_INTERVAL):
+                raise futures.TimeoutError()
+            response = client.result(pb2.InteropResultRequest(id=run_id))
+        return response
+
+    result_future = executor.submit(poll_server)
+    if timeout is None:
+        time_left = None
+    else:
+        time_left = time.time() - start_time + timeout
+    try:
+        response = result_future.result(timeout=time_left)
+    except futures.TimeoutError:
+        timeout_event.set()
+        raise
+    except KeyboardInterrupt:
+        timeout_event.set()
+        raise
+
     logger.debug("Done test run %s", run_id)
     return response
 
@@ -67,7 +95,20 @@ def main():
         logger.setLevel(logging.DEBUG)
     host = args.get('--host', 'localhost')
     port = args.get('--port', 10000)
-    results = call_test(host, port)
+    timeout = int(args.get('--timeout', 60))
+    if timeout <= 0:
+        timeout = None
+    with futures.ThreadPoolExecutor(max_workers=2) as tpe:
+        try:
+            results = call_test(host, port, tpe, timeout=timeout)
+        except futures.TimeoutError as timeout_ex:
+            logger.fatal("Timed out waiting for response from test service")
+            logger.debug(timeout_ex)
+            sys.exit(-1)
+        except grpc.RpcError as rpc_ex:
+            logger.fatal("RPC error while calling test service")
+            logger.debug(rpc_ex)
+            sys.exit(-1)
     logger.debug("Results:")
     print(results)
 

--- a/interoptest/run.py
+++ b/interoptest/run.py
@@ -104,13 +104,15 @@ def main():
         except futures.TimeoutError as timeout_ex:
             logger.fatal("Timed out waiting for response from test service")
             logger.debug(timeout_ex)
-            sys.exit(-1)
+            sys.exit(-2)
         except grpc.RpcError as rpc_ex:
             logger.fatal("RPC error while calling test service")
             logger.debug(rpc_ex)
-            sys.exit(-1)
+            sys.exit(-2)
     logger.debug("Results:")
     print(results)
+    if results.status.status == pb2.FAILURE:
+        sys.exit(-1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Adds a basic script to kick off a test and print the results. We may want to package this differently -- e.g. as an installable python package or inside another docker container -- to get rid of these symlinks and so that we don't need `grpcio` installed on the system running the tests.