### PR TITLE
Use external host address in flask service

### DIFF
--- a/interoptest/src/pythonservice/flaskserver.py
+++ b/interoptest/src/pythonservice/flaskserver.py
@@ -142,9 +142,8 @@ def block_until_ready(host, port, timeout=10):
 
 @contextmanager
 def serve_http_tracecontext(
-        port=pb2.PYTHON_HTTP_TRACECONTEXT_PROPAGATION_PORT):
+        host="0.0.0.0", port=pb2.PYTHON_HTTP_TRACECONTEXT_PROPAGATION_PORT):
     """Run the HTTP/tracecontext server, shut down on exiting context."""
-    host = 'localhost'
     with futures.ThreadPoolExecutor(max_workers=1) as tpe:
         tpe.submit(app.run, host=host, port=port)
         block_until_ready(host, port)
@@ -163,7 +162,7 @@ def test_server(port=pb2.PYTHON_HTTP_TRACECONTEXT_PROPAGATION_PORT):
                 service=pb2.Service(
                     name="python:http:tracecontext",
                     port=port,
-                    host="localhost",
+                    host="0.0.0.0",
                     spec=pb2.Spec(
                         transport=pb2.Spec.HTTP,
                         propagation=pb2.Spec.
@@ -172,7 +171,7 @@ def test_server(port=pb2.PYTHON_HTTP_TRACECONTEXT_PROPAGATION_PORT):
                 service=pb2.Service(
                     name="python:http:tracecontext",
                     port=port,
-                    host="localhost",
+                    host="0.0.0.0",
                     spec=pb2.Spec(
                         transport=pb2.Spec.HTTP,
                         propagation=pb2.Spec.
@@ -180,13 +179,13 @@ def test_server(port=pb2.PYTHON_HTTP_TRACECONTEXT_PROPAGATION_PORT):
         ])
 
     with serve_http_tracecontext():
-        return service.call_http_tracecontext('localhost', port, test_request)
+        return service.call_http_tracecontext("0.0.0.0", port, test_request)
 
 
-def main(host='localhost', port=pb2.PYTHON_HTTP_TRACECONTEXT_PROPAGATION_PORT,
+def main(host="0.0.0.0", port=pb2.PYTHON_HTTP_TRACECONTEXT_PROPAGATION_PORT,
          exit_event=None):
     """Runs the service and registers it with the test coordinator."""
-    with serve_http_tracecontext():
+    with serve_http_tracecontext(host=host, port=port):
         logger.debug("Registering with test coordinator")
         requests.post('http://{}:{}{}'.format(host, port, '/register'))
         logger.debug("Serving...")

--- a/interoptest/src/pythonservice/grpcserver.py
+++ b/interoptest/src/pythonservice/grpcserver.py
@@ -60,7 +60,7 @@ class GRPCBinaryTestServer(pb2_grpc.TestExecutionServiceServicer):
         return response
 
 
-def register(host='localhost', port=pb2.PYTHON_GRPC_BINARY_PROPAGATION_PORT):
+def register(host="0.0.0.0", port=pb2.PYTHON_GRPC_BINARY_PROPAGATION_PORT):
     """Register the server at host:port with the test registration service."""
     request = pb2.RegistrationRequest(
         server_name='python',
@@ -113,7 +113,7 @@ def test_server(port=pb2.PYTHON_GRPC_BINARY_PROPAGATION_PORT):
                 service=pb2.Service(
                     name="python:grpc:binary",
                     port=port,
-                    host="localhost",
+                    host="0.0.0.0",
                     spec=pb2.Spec(
                         transport=pb2.Spec.GRPC,
                         propagation=pb2.Spec.BINARY_FORMAT_PROPAGATION))),
@@ -121,20 +121,20 @@ def test_server(port=pb2.PYTHON_GRPC_BINARY_PROPAGATION_PORT):
                 service=pb2.Service(
                     name="python:grpc:binary",
                     port=port,
-                    host="localhost",
+                    host="0.0.0.0",
                     spec=pb2.Spec(
                         transport=pb2.Spec.GRPC,
                         propagation=pb2.Spec.BINARY_FORMAT_PROPAGATION)))
         ])
 
     with serve_grpc_binary():
-        return service.call_grpc_binary('localhost', port, test_request)
+        return service.call_grpc_binary("0.0.0.0", port, test_request)
 
 
-def main(host='localhost', port=pb2.PYTHON_GRPC_BINARY_PROPAGATION_PORT,
+def main(host="0.0.0.0", port=pb2.PYTHON_GRPC_BINARY_PROPAGATION_PORT,
          exit_event=None):
     """Runs the service and registers it with the test coordinator."""
-    with serve_grpc_binary():
+    with serve_grpc_binary(port=port):
         try:
             logger.debug("Registering with test coordinator")
             register(host, port)


### PR DESCRIPTION
Use `0.0.0.0` in place of `localhost` in the python flask service.