### PR TITLE
Lose trailing slash in flask route

### DIFF
--- a/interoptest/src/pythonservice/service.py
+++ b/interoptest/src/pythonservice/service.py
@@ -43,7 +43,7 @@ REGISTRATION_SERVER_HOST = ''
 REGISTRATION_SERVER_PORT = ''
 
 GRPC_TPE_WORKERS = 10
-HTTP_POST_PATH = "/test/request/"
+HTTP_POST_PATH = "/test/request"
 
 
 def rand63():


### PR DESCRIPTION
Use `/test/request` instead of `/test/request/`.