### PR TITLE
interoptest/tc: updates interop test service.

### DIFF
--- a/interoptest/src/testcoordinator/interoptestservice/interop_test_service.go
+++ b/interoptest/src/testcoordinator/interoptestservice/interop_test_service.go
@@ -194,6 +194,7 @@ func (s *ServiceImpl) Run(ctx context.Context, req *interop.InteropRunRequest) (
 		// TODO: consider using a semaphore instead of waiting, to make exporting deterministic
 		time.Sleep(90 * time.Second) // wait until all micro-services exported their spans
 		status := verifySpans(s.sink.SpansPerNode, id)
+		s.sink.SpansPerNode = map[*commonpb.Node][]*tracepb.Span{} // flush verified spans
 		result := &interop.TestResult{
 			Id:          id,
 			Name:        svc.Name,

--- a/interoptest/src/testcoordinator/interoptestservice/interop_test_service.go
+++ b/interoptest/src/testcoordinator/interoptestservice/interop_test_service.go
@@ -192,7 +192,7 @@ outer:
 			}
 		}
 
-		// TODO: consider using a semaphore instead of waiting, to make exporting deterministic
+		// TODO: do not verify spans until ALL test cases completed.
 		time.Sleep(20 * time.Second) // wait until all micro-services exported their spans
 		status := verifySpans(s.sink.SpansPerNode, id)
 		s.sink.SpansPerNode = map[*commonpb.Node][]*tracepb.Span{} // flush verified spans

--- a/interoptest/src/testcoordinator/interoptestservice/interop_test_service.go
+++ b/interoptest/src/testcoordinator/interoptestservice/interop_test_service.go
@@ -25,6 +25,8 @@ import (
 
 	"github.com/census-ecosystem/opencensus-experiments/interoptest/src/testcoordinator/genproto"
 	"github.com/census-ecosystem/opencensus-experiments/interoptest/src/testcoordinator/receiver"
+	"github.com/census-ecosystem/opencensus-experiments/interoptest/src/testcoordinator/testexecutionservice"
+	"github.com/census-ecosystem/opencensus-experiments/interoptest/src/testcoordinator/validator"
 	commonpb "github.com/census-instrumentation/opencensus-proto/gen-go/agent/common/v1"
 	tracepb "github.com/census-instrumentation/opencensus-proto/gen-go/trace/v1"
 	"go.opencensus.io/plugin/ocgrpc"
@@ -44,6 +46,7 @@ type ServerImpl struct {
 	startServiceOnce sync.Once
 }
 
+// NewServer returns a new unstarted gRPC interop server.
 func NewServer(addr string) (*ServerImpl, error) {
 	ln, err := net.Listen("tcp", addr)
 	if err != nil {
@@ -136,13 +139,16 @@ type ServiceImpl struct {
 	mu                 sync.Mutex
 	registeredServices map[string][]*interop.Service
 	sink               *receiver.TestCoordinatorSink
+	testSuites         map[*interop.Service][]*interop.ServiceHop
+	results            []*interop.TestResult
 }
 
 // NewService returns a new ServiceImpl with the given registered services.
 func NewService(services map[string][]*interop.Service, sink *receiver.TestCoordinatorSink) *ServiceImpl {
-	return &ServiceImpl{registeredServices: services, sink: sink}
+	return &ServiceImpl{registeredServices: services, sink: sink, testSuites: loadTestSuites()}
 }
 
+// SetRegisteredServices sets the registered services to the given one.
 func (s *ServiceImpl) SetRegisteredServices(services map[string][]*interop.Service) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -150,6 +156,7 @@ func (s *ServiceImpl) SetRegisteredServices(services map[string][]*interop.Servi
 	s.registeredServices = services
 }
 
+// Result returns all the test results.
 func (s *ServiceImpl) Result(ctx context.Context, req *interop.InteropResultRequest) (*interop.InteropResultResponse, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -157,23 +164,75 @@ func (s *ServiceImpl) Result(ctx context.Context, req *interop.InteropResultRequ
 	reps := &interop.InteropResultResponse{
 		Id:     req.Id,
 		Status: &interop.CommonResponseStatus{Status: interop.Status_SUCCESS},
-		// TODO: store and return cached result
-		Result: []*interop.TestResult{},
+		Result: s.results,
 	}
 	return reps, nil
 }
 
-// Runs the test asynchronously.
+// Run runs the test asynchronously.
 func (s *ServiceImpl) Run(ctx context.Context, req *interop.InteropRunRequest) (*interop.InteropRunResponse, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
 	id := rand.Int63()
-	// TODO: run all tests by sending out test execution requests
-	verifySpans(s.sink.SpansPerNode)
+	for svc, hops := range s.testSuites {
+		sender, _ := testexecutionservice.NewUnstartedSender(true, id, svc.Name, fmt.Sprintf("%s:%d", svc.Host, svc.Port), hops)
+		reps, err := sender.Start()
+
+		if err != nil {
+			s.results = append(s.results, getFailedResult(id, svc.Name, hops, nil))
+			continue
+		}
+
+		for _, status := range reps.Status {
+			if status.Status == interop.Status_FAILURE {
+				s.results = append(s.results, getFailedResult(id, svc.Name, hops, reps.Status))
+				continue
+			}
+		}
+
+		// TODO: consider using a semaphore instead of waiting, to make exporting deterministic
+		time.Sleep(90 * time.Second) // wait until all micro-services exported their spans
+		status := verifySpans(s.sink.SpansPerNode, id)
+		result := &interop.TestResult{
+			Id:          id,
+			Name:        svc.Name,
+			Status:      status,
+			ServiceHops: hops,
+		}
+		s.results = append(s.results, result)
+	}
 	return &interop.InteropRunResponse{Id: id}, nil
 }
 
-func verifySpans(map[*commonpb.Node][]*tracepb.Span) {
-	// TODO: implement this
+func getFailedResult(id int64, reqName string, hops []*interop.ServiceHop, details []*interop.CommonResponseStatus) *interop.TestResult {
+	return &interop.TestResult{
+		Id:          id,
+		Name:        reqName,
+		Status:      &interop.CommonResponseStatus{Status: interop.Status_FAILURE},
+		ServiceHops: hops,
+		Details:     details,
+	}
+}
+
+func verifySpans(spansPerNode map[*commonpb.Node][]*tracepb.Span, id int64) *interop.CommonResponseStatus {
+	var exportedSpans []*tracepb.Span
+	for _, spans := range spansPerNode {
+		exportedSpans = append(exportedSpans, spans...)
+	}
+	_, errs := validator.ReconstructTraces(exportedSpans...)
+	if len(errs) > 0 {
+		errMsg := "Unable to reconstruct traces:"
+		for traceID, err := range errs {
+			errMsg = fmt.Sprintf("%s %s:%s", errMsg, string(traceID[:16]), err.Error())
+		}
+		return &interop.CommonResponseStatus{Status: interop.Status_FAILURE, Error: errMsg}
+	}
+	// TODO: also verify the attributes once they're added.
+	return &interop.CommonResponseStatus{Status: interop.Status_SUCCESS}
+}
+
+func loadTestSuites() map[*interop.Service][]*interop.ServiceHop {
+	// TODO: load and parse test suites from test data
+	return map[*interop.Service][]*interop.ServiceHop{}
 }


### PR DESCRIPTION
Updates https://github.com/census-ecosystem/opencensus-experiments/issues/133.

TODO:
1. load test suites from txt files.
2. verify span attributes once they're added.