### PR TITLE
Add reqID to spans in python

### DIFF
--- a/interoptest/src/pythonservice/flaskserver.py
+++ b/interoptest/src/pythonservice/flaskserver.py
@@ -22,6 +22,7 @@ import logging
 import sys
 from concurrent import futures
 
+from opencensus.trace import execution_context
 from opencensus.trace.exporters.ocagent import trace_exporter
 from opencensus.trace.ext.flask import flask_middleware
 from opencensus.trace.propagation import trace_context_http_header_format
@@ -79,6 +80,8 @@ def test():
                   list(service.call_next(request).status))
         response = pb2.TestResponse(id=request.id, status=status)
 
+    tracer = execution_context.get_opencensus_tracer()
+    tracer.add_attribute_to_current_span("reqId", request.id)
     return response.SerializeToString()
 
 

--- a/interoptest/src/pythonservice/grpcserver.py
+++ b/interoptest/src/pythonservice/grpcserver.py
@@ -23,7 +23,7 @@ from contextlib import contextmanager
 import logging
 import sys
 
-from opencensus.trace.exporters.ocagent import trace_exporter
+from opencensus.trace import execution_context
 from opencensus.trace.ext.grpc import server_interceptor
 from opencensus.trace.samplers import always_on
 import grpc
@@ -57,6 +57,9 @@ class GRPCBinaryTestServer(pb2_grpc.TestExecutionServiceServicer):
             status = ([pb2.CommonResponseStatus(status=pb2.SUCCESS)] +
                       list(service.call_next(request).status))
             response = pb2.TestResponse(id=request.id, status=status)
+
+        tracer = execution_context.get_opencensus_tracer()
+        tracer.add_attribute_to_current_span("reqId", request.id)
         return response
 
 


### PR DESCRIPTION
Following #156, adds the request ID as a span attribute in both python services. 