### PR TITLE
interoptest: update reqId key.

### DIFF
--- a/interoptest/README.md
+++ b/interoptest/README.md
@@ -102,7 +102,7 @@ be static as long as there are no conflicts.
   
 - Request could contain a list of tags. If they do then tags should be propagated along with trace
  context. [TODO] Do all plugins provide propagation?
-- All services should add attribute "req.id" with value of the id receieved in the test request to
+- All services should add attribute "reqId" with value of the id receieved in the test request to
   current span. This is important for TestCoordinator in correlating requests with trace data 
   exported by all services via OC Agent.
 


### PR DESCRIPTION
Looks like in all the three languages (Go, Python and Node) we named this attribute "reqId", but in the spec it's "req.id".

See https://github.com/census-ecosystem/opencensus-experiments/pull/165/files#diff-52c50f72a64a669802062f7b2a245210R84, https://github.com/census-ecosystem/opencensus-experiments/pull/163/files#diff-144f321644819dda858f64caf79690aeR33 and https://github.com/census-ecosystem/opencensus-experiments/pull/156/files#diff-58a54f6d89e9a5c8d24f0e01926c7644R57.