### PR TITLE
interoptest/tc: fix a bug in TestCoordinatorSink.

### DIFF
--- a/interoptest/src/testcoordinator/receiver/sink.go
+++ b/interoptest/src/testcoordinator/receiver/sink.go
@@ -34,12 +34,7 @@ func (tcs TestCoordinatorSink) ReceiveTraceData(ctx context.Context, td data.Tra
 	node := td.Node
 	spans := td.Spans
 
-	storedSpans, ok := tcs.SpansPerNode[node]
-	if ok {
-		tcs.SpansPerNode[node] = append(storedSpans, spans...)
-	} else {
-		tcs.SpansPerNode[node] = spans
-	}
+	tcs.SpansPerNode[node] = append(tcs.SpansPerNode[node], spans...)
 
 	ack := &receiver.TraceReceiverAcknowledgement{
 		SavedSpans: uint64(len(td.Spans)),

--- a/interoptest/src/testcoordinator/receiver/sink.go
+++ b/interoptest/src/testcoordinator/receiver/sink.go
@@ -36,7 +36,7 @@ func (tcs TestCoordinatorSink) ReceiveTraceData(ctx context.Context, td data.Tra
 
 	storedSpans, ok := tcs.SpansPerNode[node]
 	if ok {
-		storedSpans = append(storedSpans, spans...)
+		tcs.SpansPerNode[node] = append(storedSpans, spans...)
 	} else {
 		tcs.SpansPerNode[node] = spans
 	}


### PR DESCRIPTION
Go `append()` is not like Java `addAll()`.