### PR TITLE
Fix a typo in the Log4j log correlation demo readme.

### DIFF
--- a/java/log_correlation/log4j2/README.md
+++ b/java/log_correlation/log4j2/README.md
@@ -57,8 +57,9 @@ described in https://cloud.google.com/logging/docs/agent/configuration#structure
 that the demo project's `log4j2.xml` and the fluentd configuration specify the same log file.
 
 4. Add the following fluentd filter to transform Log4j's `level` field into the `severity` field
-that is expected by Stackdriver.  This snippet can be appended to the file from step 4.  Ensure that
-the tag on the first line of the snippet matches the tag in the fluentd configuration file from step 4.
+that is expected by Stackdriver.  This snippet can be appended to the fluentd configuration file
+that was added in step 3.  Ensure that the tag on the first line of the snippet matches the tag in
+the configuration from step 3.
 
   ```xml
   <filter structured-log>


### PR DESCRIPTION
The steps in the instructions were renumbered in
f4502bfcb86082696fa7f0cbc5d56336f422ea1d, and one reference to a step number
wasn't updated.